### PR TITLE
v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![View Plugin for MATLAB Parallel Server with Kubernetes on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/120243-plugin-for-matlab-parallel-server-with-kubernetes)
 
+:warning: **Starting in R2024a, the Parallel Computing Toolbox Plugin for MATLAB Parallel Server with Kubernetes is no longer supported. Use the MATLAB Parallel Server in Kubernetes reference architecture instead. To learn more, see the [MATLAB Parallel Server in Kubernetes](https://github.com/mathworks-ref-arch/matlab-parallel-server-on-kubernetes) GitHub repository.**
+---
+
 Parallel Computing Toolbox&trade; provides the `Generic` cluster type for submitting MATLAB&reg; jobs to a cluster running a third-party scheduler.
 The `Generic` type uses a set of plugin scripts to define how your machine communicates with your scheduler.
 You can customize the plugin scripts to configure how MATLAB interacts with the scheduler to best suit your cluster setup and support custom submission options.
@@ -53,7 +56,7 @@ Alternatively, to clone this repository to your computer with Git software, ente
 git clone https://github.com/mathworks/matlab-parallel-kubernetes-plugin
 ```
 
-#### 2. Create Kubernetes Namespace and Limit Resources
+#### 2. Create Kubernetes Namespace
 
 Kubernetes uses namespaces to separate groups of resources.
 For more information, see the documentation for [Namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) on the Kubernetes website.
@@ -64,17 +67,6 @@ To create a custom namespace with the name `my-namespace`, run this command:
 ```
 kubectl create namespace my-namespace
 ```
-
-##### Limit Kubernetes Pods in Namespace
-
-You can limit the number of pods that can run simultaneously in a namespace.
-Each MATLAB Parallel Server worker requires one pod.
-By limiting the number of pods to run simultaneously, you can limit the number of MATLAB Parallel Server workers that run simultaneously.
-If your MATLAB Parallel Server license has fewer than 200 workers, limit the number of pods to the number of MATLAB Parallel Server workers by running this command:
-```
-kubectl create resourcequota quota-name --namespace my-namespace --hard pods=numWorkers
-```
-`quota-name` is the name of the resource quota, `my-namespace` is the namespace, and `numWorkers` is the number of MATLAB Parallel Server workers on your license.
 
 #### 3. Set Up PersistentVolumeClaim for Job Storage
 
@@ -140,7 +132,7 @@ To build a Docker image with a built-in MATLAB and MATLAB Parallel Server instal
 
 To build the image, run this command from within the `image/` folder:
 ```
-docker build . -t image-name --build-arg MATLAB_RELEASE=release --build-arg INSTALL_MATLAB=true --build-arg LICENSE_SERVER=port@hostname ADDITIONAL_PRODUCTS="Product1 Product2"
+docker build . -t image-name --build-arg MATLAB_RELEASE=release --build-arg INSTALL_MATLAB=true
 ```
 
 By default, this command installs all MATLAB toolboxes included with a MATLAB Parallel Server license.
@@ -457,4 +449,4 @@ The license is available in the [license.txt](license.txt) file in this reposito
 
 If you require assistance or have a request for additional features or capabilities, please contact [MathWorks Technical Support](https://www.mathworks.com/support/contact_us.html).
 
-Copyright 2022-2023 The MathWorks, Inc.
+Copyright 2022-2024 The MathWorks, Inc.

--- a/cancelJobFcn.m
+++ b/cancelJobFcn.m
@@ -1,44 +1,8 @@
 function ok = cancelJobFcn(cluster, job)
-% Cancel a job submitted to a Kubernetes cluster by uninstalling the helm
-% release associated with the job.
+% Cancel a job submitted to a Kubernetes cluster.
 
 % Copyright 2022-2023 The MathWorks, Inc.
 
-if cluster.getJobClusterData(job).HelmUninstalled
-    ok = true;
-    return
-end
+ok = cancelJobOnCluster(cluster, job);
 
-release = cluster.getJobClusterData(job).HelmRelease;
-exitCode = iUninstallRelease(cluster, release);
-
-if cluster.RequiresOnlineLicensing
-    iDeleteUserCredSecret(cluster, job);
-end
-
-ok = exitCode == 0;
-if ok
-    iSetUninstalledFlag(cluster, job, true);
-end
-end
-
-function iSetUninstalledFlag(cluster, job, flag)
-data = cluster.getJobClusterData(job);
-data.HelmUninstalled = flag;
-cluster.setJobClusterData(job, data);
-end
-
-function exitCode = iUninstallRelease(cluster, release)
-commandToRun = "helm uninstall " + release;
-[exitCode, result] = runKubeCmd(commandToRun, cluster, false);
-if exitCode ~= 0
-    warning("parallelexamples:GenericKubernetes:HelmUninstallFailed", ...
-        "Failed to uninstall Helm release: %s", result);
-end
-end
-
-function exitCode = iDeleteUserCredSecret(cluster, job)
-secretName = cluster.getJobClusterData(job).UserCredSecret;
-commandToRun = "kubectl delete secret " + secretName;
-exitCode = runKubeCmd(commandToRun, cluster, false);
 end

--- a/cancelTaskFcn.m
+++ b/cancelTaskFcn.m
@@ -3,21 +3,6 @@ function ok = cancelTaskFcn(cluster, task)
 
 % Copyright 2022-2023 The MathWorks, Inc.
 
-% We can't cancel a single task of a communicating job on the scheduler
-% without cancelling the entire job, so warn and return in this case
-if ~strcmpi(task.Parent.Type, 'independent')
-    ok = false;
-    warning('parallelexamples:GenericKubernetes:FailedToCancelTask', ...
-        'Unable to cancel a single task of a communicating job. If you want to cancel the entire job, use the cancel function on the job object instead.');
-    return
-end
+ok = cancelTaskOnCluster(cluster, task);
 
-% For independent jobs, delete the kubernetes job corresponding to the task
-commandToRun = "kubectl delete job -l taskUID=" + task.SchedulerID;
-[exitCode, result] = runKubeCmd(commandToRun, cluster, false);
-ok = exitCode == 0;
-if ~ok
-    warning("parallelexamples:GenericKubernetes:HelmUninstallFailed", ...
-        "Failed to uninstall Helm release: %s", result);
-end
 end

--- a/deleteJobFcn.m
+++ b/deleteJobFcn.m
@@ -1,8 +1,8 @@
 function deleteJobFcn(cluster, job)
 % Delete a job submitted to a Kubernetes cluster.
 
-% Copyright 2022 The MathWorks, Inc.
+% Copyright 2022-2023 The MathWorks, Inc.
 
-cancelJobFcn(cluster, job);
+cancelJobOnCluster(cluster, job);
 
 end

--- a/deleteTaskFcn.m
+++ b/deleteTaskFcn.m
@@ -1,8 +1,8 @@
 function deleteTaskFcn(cluster, task)
 % Delete a task submitted to a Kubernetes cluster.
 
-% Copyright 2022 The MathWorks, Inc.
+% Copyright 2022-2023 The MathWorks, Inc.
 
-cancelTaskFcn(cluster, task);
+cancelTaskOnCluster(cluster, task);
 
 end

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2022-2023 The MathWorks, Inc.
-ARG MATLAB_RELEASE=r2023a
+ARG MATLAB_RELEASE=r2023b
 ARG MATLAB_DEPS_IMAGE=mathworks/matlab-deps
 FROM ${MATLAB_DEPS_IMAGE}:${MATLAB_RELEASE}
 LABEL maintainer="The MathWorks"
@@ -37,6 +37,14 @@ RUN apt-get update && apt-get install --yes --no-install-recommends openssh-clie
 RUN if [ "${MATLAB_RELEASE}" = "r2023a" ]; then \
         apt-get update && \
         apt-get install --yes --no-install-recommends libunwind8 && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*; \
+        fi
+
+# Install libatomic on R2023b - needed by mpich 4
+RUN if [ "${MATLAB_RELEASE}" = "r2023b" ]; then \
+        apt-get update && \
+        apt-get install --yes --no-install-recommends libatomic1 && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/*; \
         fi

--- a/private/cancelJobOnCluster.m
+++ b/private/cancelJobOnCluster.m
@@ -1,0 +1,44 @@
+function ok = cancelJobOnCluster(cluster, job)
+% Cancel a job on the Kubernetes cluster by uninstalling the helm
+% release associated with the job.
+
+% Copyright 2022-2023 The MathWorks, Inc.
+
+if cluster.getJobClusterData(job).HelmUninstalled
+    ok = true;
+    return
+end
+
+release = cluster.getJobClusterData(job).HelmRelease;
+exitCode = iUninstallRelease(cluster, release);
+
+if cluster.RequiresOnlineLicensing
+    iDeleteUserCredSecret(cluster, job);
+end
+
+ok = exitCode == 0;
+if ok
+    iSetUninstalledFlag(cluster, job, true);
+end
+end
+
+function iSetUninstalledFlag(cluster, job, flag)
+data = cluster.getJobClusterData(job);
+data.HelmUninstalled = flag;
+cluster.setJobClusterData(job, data);
+end
+
+function exitCode = iUninstallRelease(cluster, release)
+commandToRun = "helm uninstall " + release;
+[exitCode, result] = runKubeCmd(commandToRun, cluster, false);
+if exitCode ~= 0
+    warning("parallelexamples:GenericKubernetes:HelmUninstallFailed", ...
+        "Failed to uninstall Helm release: %s", result);
+end
+end
+
+function exitCode = iDeleteUserCredSecret(cluster, job)
+secretName = cluster.getJobClusterData(job).UserCredSecret;
+commandToRun = "kubectl delete secret " + secretName;
+exitCode = runKubeCmd(commandToRun, cluster, false);
+end

--- a/private/cancelTaskOnCluster.m
+++ b/private/cancelTaskOnCluster.m
@@ -1,0 +1,23 @@
+function ok = cancelTaskOnCluster(cluster, task)
+% Cancel a task on the Kubernetes cluster.
+
+% Copyright 2022-2023 The MathWorks, Inc.
+
+% We can't cancel a single task of a communicating job on the scheduler
+% without cancelling the entire job, so warn and return in this case
+if ~strcmpi(task.Parent.Type, 'independent')
+    ok = false;
+    warning('parallelexamples:GenericKubernetes:FailedToCancelTask', ...
+        'Unable to cancel a single task of a communicating job. If you want to cancel the entire job, use the cancel function on the job object instead.');
+    return
+end
+
+% For independent jobs, delete the kubernetes job corresponding to the task
+commandToRun = "kubectl delete job -l taskUID=" + task.SchedulerID;
+[exitCode, result] = runKubeCmd(commandToRun, cluster, false);
+ok = exitCode == 0;
+if ~ok
+    warning("parallelexamples:GenericKubernetes:HelmUninstallFailed", ...
+        "Failed to uninstall Helm release: %s", result);
+end
+end


### PR DESCRIPTION
Release Notes:

New features:
- The README now contains a deprecation note and a link to the new reference architecture for MATLAB Job Scheduler in Kubernetes.

Bug fixes:
- Installed the libatomic library on the Docker image to support MPI in R2023b.
- Fixed the "docker build" command to remove unnecessary build arguments.
- Removed the instruction to create a resource quota from the README, as this has the side effect of making scheduling very inefficient.
- Moved job and task cancellation functions into the "private" subfolder for consistency with the other plugin scripts.